### PR TITLE
Add `onlyFields` options to target only some locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Handle localisation with a templated Google Spreadsheet
     1. [New Google Sheets from a template](https://docs.google.com/spreadsheets/u/0/?ftv=1&folder=0ABUmECcOxpcZUk9PVA&tgif=d)
     2. Choose `Template_tool_i18n` tempate
     3. Add/Remove/Update languages the project need to support
-    5. **The spreadsheet must be public !** Go to _File > Share > Publish to the web_ to make it public.
-    4. That'it !
+    5. **The spreadsheet must be public!** Go to _File > Share > Publish to the web_ to make it public.
+    4. That'it!
 
 ## Installation
 
@@ -32,13 +32,14 @@ npm i git+ssh://git@github.com:makemepulse/makemepulse-tool-i18n.git
 
 ## Options
 
-| Argument             | Type    | Description                                                 | Default                                    |
-| -------------------- | ------- | ----------------------------------------------------------- | ------------------------------------------ |
-| `--spreadsheet-id`   | string  | The id of the spreadsheet                                   | `process.env.I18N_SPREADSHEET_ID`    |
-| `--spreadsheet-tab`  | string  | The tab of the spreadsheet                                  | `"locales"`    |
-| `--ignore-fields`    | string  | Comma-separated list of fields whiches **are not** locales  | `ID,category,key,description,status`
-| `--locales-dir`      | string  | The path of the locales folder                              | `src/locales`
-| `--prettify`         | boolean | Format the JSON output                                      | `false`
+| CLI argument         | Env variable           | Type    | Description                                                     | Default                                    |
+| -------------------- | ---------------------- | ------- | --------------------------------------------------------------- | ------------------------------------------ |
+| `--spreadsheet-id`   | `I18N_SPREADSHEET_ID`  | string  | The id of the spreadsheet                                       | `""`                                       |
+| `--spreadsheet-tab`  | `I18N_SPREADSHEET_TAB` | string  | The tab of the spreadsheet                                      | `"locales"`                                |
+| `--ignore-fields`    | `I18N_IGNORE_FIELDS`   | string  | Comma-separated list of fields that **are not** locales         | `"ID,category,key,description,status"`     |
+| `--only-fields`      | `I18N_ONLY_FIELDS`     | string  | Comma-separated list of fields to target **only** these locales | `""`                                       |
+| `--locales-dir`      | `I18N_LOCALES_DIR`     | string  | The path of the locales folder                                  | `"src/locales"`                            |
+| `--prettify`         | -                      | boolean | Format the JSON output                                          | `false`                                    |
 
 
 ## Settings
@@ -74,7 +75,7 @@ Add the following commands to your `package.json` file:
 
 ### Arabic language
 
-*Please note that if your project needs arabic locales and if there is Latin character in your arabic locales, you must the  `v-html` directive to display the locales*
+*Please note that if your project needs arabic locales and if there is Latin character in your arabic locales, you must the `v-html` directive to display the locales*
 
 ## Test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmp-tool-i18n",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "handle locales with Google Spreadsheet and vue-i18n plugin",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/Fetch.test.ts
+++ b/src/__tests__/Fetch.test.ts
@@ -8,18 +8,22 @@ require('dotenv').config({ path: path.resolve(process.cwd(), '.env.local') });
 const DEFAULT_IGNORE_FIELDS = ['ID', 'category', 'key', 'description', 'status'];
 
 const argv = parseArgs(process.argv.slice(2), {
-  string: ['ignore-fields', 'spreadsheet-id', 'spreadsheet-tab'],
-  boolean: ['prettify']
+  string: ['spreadsheet-id', 'spreadsheet-tab', 'ignore-fields', 'only-fields', 'locales-dir'],
+  boolean: ['prettify'],
 }) as ArgumentValues;
 
-const ignoreFields = argv['ignore-fields']
-  ? argv['ignore-fields'].split(',').map(field => field.trim())
+const customIgnoreFields = process.env.I18N_IGNORE_FIELDS || argv['ignore-fields'];
+const ignoreFields = customIgnoreFields
+  ? customIgnoreFields.split(',').map((field) => field.trim())
   : DEFAULT_IGNORE_FIELDS;
-const options:I18nFetchOptions = {
+const customOnlyFields = process.env.I18N_ONLY_FIELDS || argv['only-fields'];
+const onlyFields = customOnlyFields?.split(',').map((field) => field.trim());
+const options: I18nFetchOptions = {
   appId: (process.env.I18N_SPREADSHEET_ID || argv['spreadsheet-id'])!,
   tab: process.env.I18N_SPREADSHEET_TAB || argv['spreadsheet-tab'] || 'locales',
-  ignoreFields
-}
+  ignoreFields,
+  onlyFields,
+};
 
 test(`Fetch Google Spreadsheet ${options.appId}`, async () => {
   await fetch(options).then(exportFiles);

--- a/src/__tests__/Upsync.test.ts
+++ b/src/__tests__/Upsync.test.ts
@@ -8,18 +8,21 @@ require('dotenv').config({ path: path.resolve(process.cwd(), '.env.local') });
 const DEFAULT_IGNORE_FIELDS = ['ID', 'category', 'key', 'description', 'status'];
 
 const argv = parseArgs(process.argv.slice(2), {
-  string: ['ignore-fields', 'spreadsheet-id', 'spreadsheet-tab', 'locales-dir']
+  string: ['spreadsheet-id', 'spreadsheet-tab', 'ignore-fields', 'only-fields', 'locales-dir'],
 }) as ArgumentValues;
 
-const ignoreFields = argv['ignore-fields']
-  ? argv['ignore-fields'].split(',').map(field => field.trim())
+const customIgnoreFields = process.env.I18N_IGNORE_FIELDS || argv['ignore-fields'];
+const ignoreFields = customIgnoreFields
+  ? customIgnoreFields.split(',').map((field) => field.trim())
   : DEFAULT_IGNORE_FIELDS;
-const options:I18nFetchOptions = {
+const customOnlyFields = process.env.I18N_ONLY_FIELDS || argv['only-fields'];
+const onlyFields = customOnlyFields?.split(',').map((field) => field.trim());
+const options: I18nFetchOptions = {
   appId: (process.env.I18N_SPREADSHEET_ID || argv['spreadsheet-id'])!,
   tab: process.env.I18N_SPREADSHEET_TAB || argv['spreadsheet-tab'] || 'locales',
-  ignoreFields
-}
-
+  ignoreFields,
+  onlyFields,
+};
 
 test(`UpSync`, async () => {
   await upsync(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,18 +8,21 @@ require('dotenv').config({ path: path.resolve(process.cwd(), '.env.local') });
 const DEFAULT_IGNORE_FIELDS = ['ID', 'category', 'key', 'description', 'status'];
 
 const argv = parseArgs(process.argv.slice(2), {
-  string: ['ignore-fields', 'spreadsheet-id', 'spreadsheet-tab'],
-  boolean: ['prettify']
+  string: ['spreadsheet-id', 'spreadsheet-tab', 'ignore-fields', 'only-fields', 'locales-dir'],
+  boolean: ['prettify'],
 }) as ArgumentValues;
 
-const customIgnoreFields = process.env.I18N_IGNORE_FIELDS || argv['ignore-fields']
+const customIgnoreFields = process.env.I18N_IGNORE_FIELDS || argv['ignore-fields'];
 const ignoreFields = customIgnoreFields
-  ? customIgnoreFields.split(',').map(field => field.trim())
+  ? customIgnoreFields.split(',').map((field) => field.trim())
   : DEFAULT_IGNORE_FIELDS;
-const options:I18nFetchOptions = {
+const customOnlyFields = process.env.I18N_ONLY_FIELDS || argv['only-fields'];
+const onlyFields = customOnlyFields?.split(',').map((field) => field.trim());
+const options: I18nFetchOptions = {
   appId: (process.env.I18N_SPREADSHEET_ID || argv['spreadsheet-id'])!,
   tab: process.env.I18N_SPREADSHEET_TAB || argv['spreadsheet-tab'] || 'locales',
-  ignoreFields
-}
+  ignoreFields,
+  onlyFields,
+};
 
 fetch(options).then(exportFiles);

--- a/src/upsync.ts
+++ b/src/upsync.ts
@@ -8,16 +8,20 @@ require('dotenv').config({ path: path.resolve(process.cwd(), '.env.local') });
 const DEFAULT_IGNORE_FIELDS = ['ID', 'category', 'key', 'description', 'status'];
 
 const argv = parseArgs(process.argv.slice(2), {
-  string: ['ignore-fields', 'spreadsheet-id', 'spreadsheet-tab', 'locales-dir']
+  string: ['spreadsheet-id', 'spreadsheet-tab', 'ignore-fields', 'only-fields', 'locales-dir'],
 }) as ArgumentValues;
 
-const ignoreFields = argv['ignore-fields']
-  ? argv['ignore-fields'].split(',').map(field => field.trim())
+const customIgnoreFields = process.env.I18N_IGNORE_FIELDS || argv['ignore-fields'];
+const ignoreFields = customIgnoreFields
+  ? customIgnoreFields.split(',').map((field) => field.trim())
   : DEFAULT_IGNORE_FIELDS;
-const options:I18nFetchOptions = {
+const customOnlyFields = process.env.I18N_ONLY_FIELDS || argv['only-fields'];
+const onlyFields = customOnlyFields?.split(',').map((field) => field.trim());
+const options: I18nFetchOptions = {
   appId: (process.env.I18N_SPREADSHEET_ID || argv['spreadsheet-id'])!,
   tab: process.env.I18N_SPREADSHEET_TAB || argv['spreadsheet-tab'] || 'locales',
-  ignoreFields
-}
+  ignoreFields,
+  onlyFields,
+};
 
 upsync(options);


### PR DESCRIPTION
Use `onlyFields` option to specify which locale(s) you want to target.
So instead of adding undesirable locales to `ignoreFields` options, you can just declare the ones you actually want.

e.g. You have 3 locales in the spreadsheet, let's say "FR / EN / DE / ES / IT" and only the french and english copies are ready for prod, just add `--only-fields=fr,en` to your i18n command (or use the env var `I18N_ONLY_FIELDS=fr,en`)

—
In addition to this, the `ignoreFields` and `onlyFields` options are now case insensitive :)