### PR TITLE
Handle both private and public IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Handle localisation with a templated Google Spreadsheet
     1. [New Google Sheets from a template](https://docs.google.com/spreadsheets/u/0/?ftv=1&folder=0ABUmECcOxpcZUk9PVA&tgif=d)
     2. Choose `Template_tool_i18n` tempate
     3. Add/Remove/Update languages the project need to support
-    5. **The spreadsheet must be public!** Go to _File > Share > Publish to the web_ to make it public.
-    4. That'it!
+    4. **The spreadsheet must be public!** Go to _File > Share > Publish to the web_ to make it public.
+    5. Copy the ID starting with `2PACX-` inside the public link.
+    5. That'it!
 
 ## Installation
 
@@ -34,7 +35,7 @@ npm i git+ssh://git@github.com:makemepulse/makemepulse-tool-i18n.git
 
 | CLI argument         | Env variable           | Type    | Description                                                     | Default                                    |
 | -------------------- | ---------------------- | ------- | --------------------------------------------------------------- | ------------------------------------------ |
-| `--spreadsheet-id`   | `I18N_SPREADSHEET_ID`  | string  | The id of the spreadsheet                                       | `""`                                       |
+| `--spreadsheet-id`   | `I18N_SPREADSHEET_ID`  | string  | The ID of the spreadsheet. To avoid 401 errors, use the public one starting with `2PACX-`                                       | `""`                                       |
 | `--spreadsheet-tab`  | `I18N_SPREADSHEET_TAB` | string  | The tab of the spreadsheet                                      | `"locales"`                                |
 | `--ignore-fields`    | `I18N_IGNORE_FIELDS`   | string  | Comma-separated list of fields that **are not** locales         | `"ID,category,key,description,status"`     |
 | `--only-fields`      | `I18N_ONLY_FIELDS`     | string  | Comma-separated list of fields to target **only** these locales | `""`                                       |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makemepulse/tool-i18n",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Handle locales with Google Spreadsheet and vue-i18n plugin",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://"
+    "url": "https://github.com/makemepulse/makemepulse-tool-i18n"
   },
   "keywords": [
-    "vue-i18n"
+    "vue",
+    "i18n"
   ],
   "author": "makemepulse",
   "license": "ISC",
   "bugs": {
-    "url": "git+https://"
+    "url": "https://github.com/makemepulse/makemepulse-tool-i18n/issues"
   },
   "homepage": "#readme",
   "devDependencies": {

--- a/src/mmp-tool-i18n.ts
+++ b/src/mmp-tool-i18n.ts
@@ -123,15 +123,16 @@ function getParameterCaseInsensitive(object: Record<string, any>, key: string) {
  * @param url
  * @returns
  */
-export async function getWorkBook(url: string): Promise<WorkBook> {
+export async function getWorkBook(url?: string): Promise<WorkBook> {
   if (_WORKBOOK) return _WORKBOOK;
 
   if (!fs.existsSync('./.tmp')) {
     mkdirp.sync('.tmp');
   }
 
-  const { appId: filename = 'locale' } = _OPTIONS;
-  const tmpFile = `./.tmp/${filename}.xlsx`;
+  const { appId } = _OPTIONS;
+  const tmpFile = `./.tmp/${appId}.xlsx`;
+  url = url ?? `https://docs.google.com/spreadsheets/d/${appId.startsWith("2PACX-") ? `e/${appId}` : appId}/pub?output=xlsx`;
 
   try {
     await downloadFile(url, tmpFile);
@@ -182,8 +183,7 @@ export async function fetch(options: I18nFetchOptions): Promise<I18nData> {
 
   console.log('[i18n] fetch', _OPTIONS);
 
-  const workbookURL = `https://docs.google.com/spreadsheets/d/${_OPTIONS.appId}/pub?output=xlsx`;
-  await getWorkBook(workbookURL);
+  await getWorkBook();
 
   let tabs = _OPTIONS.tab.split(',').map((tab) => tab.trim());
   var records: I18nData[] = [];
@@ -262,7 +262,7 @@ export async function upsync(options: I18nFetchOptions): Promise<Boolean> {
 
   console.log('[i18n] upsync', _OPTIONS);
 
-  await getWorkBook(`https://docs.google.com/spreadsheets/d/${_OPTIONS.appId}/pub?output=xlsx`);
+  await getWorkBook();
 
   var records: I18nData[] = XLSX.utils.sheet_to_json(_WORKBOOK.Sheets[_OPTIONS.tab], { raw: false, defval: '' });
   if (!records[0]) {


### PR DESCRIPTION
Sometimes you can have 401 errors when fetching xlsx with default spreadsheet ID…
It's generally better to use the public ID, the one starting with `2PACX-`.

Both IDs are now handled, so there is no regression with this improvement.